### PR TITLE
Update inventory_source_update -- fix name of async status job

### DIFF
--- a/roles/inventory_source_update/tasks/main.yml
+++ b/roles/inventory_source_update/tasks/main.yml
@@ -30,7 +30,7 @@
   vars:
     ansible_async_dir: '/tmp/.ansible_async'
 
-- name: "Configure Inventory Source | Wait for finish the Inventory Source creation"
+- name: "Controller inventory source update | Wait for finish of the inventory source update"
   ansible.builtin.async_status:
     jid: "{{ __inventory_source_update_async_results_item.ansible_job_id }}"
   register: __inventory_source_update_async_result


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Change the name of the async status job task in inventory source update, I'd guess the name was copied from inventory_source without changing it for this job
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
No functional changes
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
No
<!--- Provide a link to any open issues that describe the problem you are solving. -->


# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
